### PR TITLE
4.8.0.0.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Mediation SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
-### 4.8.0.0.0
+### 4.8.0.0.0.0
 - This version of the adapter has been certified with ironSource SDK 8.0.0.
 
 ### 4.7.9.0.0.0

--- a/IronSourceAdapter/build.gradle.kts
+++ b/IronSourceAdapter/build.gradle.kts
@@ -36,7 +36,7 @@ android {
         minSdk = 21
         targetSdk = 33
         // If you touch the following line, don't forget to update scripts/get_rc_version.zsh
-        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "4.8.0.0.0"
+        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "4.8.0.0.0.0"
 
         buildConfigField("String", "CHARTBOOST_MEDIATION_IRONSOURCE_ADAPTER_VERSION", "\"${android.defaultConfig.versionName}\"")
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Chartboost Mediation ironSource adapter mediates ironSource via the Chartboo
 
 In your `build.gradle`, add the following entry:
 ```
-    implementation "com.chartboost:chartboost-mediation-adapter-ironsource:4.8.0.0.0"
+    implementation "com.chartboost:chartboost-mediation-adapter-ironsource:4.8.0.0.0.0"
 ```
 
 ## Contributions


### PR DESCRIPTION
The version number for the previous tagged release was improperly set (by automation, I think) to be `4.8.0.0.0`, but IronSource adapter has an extra value, so it has to be `4.8.0.0.0.0`.