### PR TITLE
[HB-5985] Bidding support for fullscreen ad formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Mediation SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
+### 4.8.2.0.0.1
+- Added bidding support for fullscreen ad formats.
+
 ### 4.8.2.0.0.0
 - This version of the adapter has been certified with ironSource SDK 8.2.0.
 

--- a/IronSourceAdapter/build.gradle.kts
+++ b/IronSourceAdapter/build.gradle.kts
@@ -36,7 +36,7 @@ android {
         minSdk = 21
         targetSdk = 33
         // If you touch the following line, don't forget to update scripts/get_rc_version.zsh
-        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "4.8.2.0.0.0"
+        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "4.8.2.0.0.1"
 
         buildConfigField("String", "CHARTBOOST_MEDIATION_IRONSOURCE_ADAPTER_VERSION", "\"${android.defaultConfig.versionName}\"")
 

--- a/IronSourceAdapter/src/main/java/com/chartboost/mediation/ironsourceadapter/IronSourceAdapter.kt
+++ b/IronSourceAdapter/src/main/java/com/chartboost/mediation/ironsourceadapter/IronSourceAdapter.kt
@@ -232,9 +232,9 @@ class IronSourceAdapter : PartnerAdapter {
         context: Context,
         request: PreBidRequest,
     ): Map<String, String> {
-        PartnerLogController.log(BIDDER_INFO_FETCH_STARTED)
-        PartnerLogController.log(BIDDER_INFO_FETCH_SUCCEEDED)
-        return emptyMap()
+        val token = IronSource.getISDemandOnlyBiddingData(context) ?: ""
+        PartnerLogController.log(if (token.isNotEmpty()) BIDDER_INFO_FETCH_SUCCEEDED else BIDDER_INFO_FETCH_FAILED)
+        return mapOf("token" to token)
     }
 
     /**
@@ -350,7 +350,12 @@ class IronSourceAdapter : PartnerAdapter {
                     listener = listener,
                 )
             )
-            IronSource.loadISDemandOnlyInterstitial(activity, request.partnerPlacement)
+
+            if (request.adm.isNullOrEmpty()) {
+                IronSource.loadISDemandOnlyInterstitial(activity, request.partnerPlacement)
+            } else {
+                IronSource.loadISDemandOnlyInterstitialWithAdm(activity, request.partnerPlacement, request.adm)
+            }
         }
     }
 
@@ -394,7 +399,12 @@ class IronSourceAdapter : PartnerAdapter {
                     listener = listener,
                 )
             )
-            IronSource.loadISDemandOnlyRewardedVideo(activity, request.partnerPlacement)
+
+            if (request.adm.isNullOrEmpty()) {
+                IronSource.loadISDemandOnlyRewardedVideo(activity, request.partnerPlacement)
+            } else {
+                IronSource.loadISDemandOnlyRewardedVideoWithAdm(activity, request.partnerPlacement, request.adm)
+            }
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Chartboost Mediation ironSource adapter mediates ironSource via the Chartboo
 
 In your `build.gradle`, add the following entry:
 ```
-    implementation "com.chartboost:chartboost-mediation-adapter-ironsource:4.8.2.0.0.0"
+    implementation "com.chartboost:chartboost-mediation-adapter-ironsource:4.8.2.0.0.1"
 ```
 
 ## Contributions


### PR DESCRIPTION
- Added bidding support for fullscreen ad formats.
- Updated adapter version to 4.8.2.0.0.1 for Mediation 4.x
- Targeting `main` but cannot be merged into `main`
- Supersedes https://github.com/ChartBoost/chartboost-mediation-android-adapter-ironsource/pull/47