### PR TITLE
[HB-5985] Bidding support for fullscreen ad formats - Mediation 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,14 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Mediation SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
+### 5.8.2.0.0.1
+- Added bidding support for fullscreen ad formats for Mediation 5.
+
 ### 5.8.2.0.0.0
 - This version of the adapter supports Chartboost Mediation SDK version 5.+.
+
+### 4.8.2.0.0.1
+- Added bidding support for fullscreen ad formats.
 
 ### 4.8.2.0.0.0
 - This version of the adapter has been certified with ironSource SDK 8.2.0.

--- a/IronSourceAdapter/build.gradle.kts
+++ b/IronSourceAdapter/build.gradle.kts
@@ -43,7 +43,7 @@ android {
         minSdk = 21
         targetSdk = 34
         // If you touch the following line, don't forget to update scripts/get_rc_version.zsh
-        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "5.8.2.0.0.0"
+        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "5.8.2.0.0.1"
 
         buildConfigField("String", "CHARTBOOST_MEDIATION_IRONSOURCE_ADAPTER_VERSION", "\"${android.defaultConfig.versionName}\"")
 

--- a/IronSourceAdapter/src/main/java/com/chartboost/mediation/ironsourceadapter/IronSourceAdapter.kt
+++ b/IronSourceAdapter/src/main/java/com/chartboost/mediation/ironsourceadapter/IronSourceAdapter.kt
@@ -21,8 +21,8 @@ import com.chartboost.chartboostmediationsdk.domain.PartnerAdapter
 import com.chartboost.chartboostmediationsdk.domain.PartnerAdapterConfiguration
 import com.chartboost.chartboostmediationsdk.domain.PartnerConfiguration
 import com.chartboost.chartboostmediationsdk.utils.PartnerLogController
-import com.chartboost.chartboostmediationsdk.utils.PartnerLogController.PartnerAdapterEvents.BIDDER_INFO_FETCH_STARTED
 import com.chartboost.chartboostmediationsdk.utils.PartnerLogController.PartnerAdapterEvents.BIDDER_INFO_FETCH_SUCCEEDED
+import com.chartboost.chartboostmediationsdk.utils.PartnerLogController.PartnerAdapterEvents.BIDDER_INFO_FETCH_FAILED
 import com.chartboost.chartboostmediationsdk.utils.PartnerLogController.PartnerAdapterEvents.CUSTOM
 import com.chartboost.chartboostmediationsdk.utils.PartnerLogController.PartnerAdapterEvents.DID_CLICK
 import com.chartboost.chartboostmediationsdk.utils.PartnerLogController.PartnerAdapterEvents.DID_DISMISS
@@ -203,9 +203,9 @@ class IronSourceAdapter : PartnerAdapter {
         context: Context,
         request: PartnerAdPreBidRequest,
     ): Result<Map<String, String>> {
-        PartnerLogController.log(BIDDER_INFO_FETCH_STARTED)
-        PartnerLogController.log(BIDDER_INFO_FETCH_SUCCEEDED)
-        return Result.success(emptyMap())
+        val token = IronSource.getISDemandOnlyBiddingData(context) ?: ""
+        PartnerLogController.log(if (token.isNotEmpty()) BIDDER_INFO_FETCH_SUCCEEDED else BIDDER_INFO_FETCH_FAILED)
+        return Result.success(mapOf("token" to token))
     }
 
     /**
@@ -363,7 +363,12 @@ class IronSourceAdapter : PartnerAdapter {
                     listener = listener,
                 )
             )
-            IronSource.loadISDemandOnlyInterstitial(activity, request.partnerPlacement)
+
+            if (request.adm.isNullOrEmpty()) {
+                IronSource.loadISDemandOnlyInterstitial(activity, request.partnerPlacement)
+            } else {
+                IronSource.loadISDemandOnlyInterstitialWithAdm(activity, request.partnerPlacement, request.adm)
+            }
         }
     }
 
@@ -407,7 +412,12 @@ class IronSourceAdapter : PartnerAdapter {
                     listener = listener,
                 )
             )
-            IronSource.loadISDemandOnlyRewardedVideo(activity, request.partnerPlacement)
+
+            if (request.adm.isNullOrEmpty()) {
+                IronSource.loadISDemandOnlyRewardedVideo(activity, request.partnerPlacement)
+            } else {
+                IronSource.loadISDemandOnlyRewardedVideoWithAdm(activity, request.partnerPlacement, request.adm)
+            }
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Chartboost Mediation ironSource adapter mediates ironSource via the Chartboo
 
 In your `build.gradle`, add the following entry:
 ```
-    implementation "com.chartboost:chartboost-mediation-adapter-ironsource:5.8.2.0.0.0"
+    implementation "com.chartboost:chartboost-mediation-adapter-ironsource:5.8.2.0.0.1"
 ```
 
 ## Contributions


### PR DESCRIPTION
- Added bidding support for fullscreen ad formats.
- Updated adapter version to 5.8.2.0.0.1 for Mediation 5.x

Mediation 4 version: https://github.com/ChartBoost/chartboost-mediation-android-adapter-ironsource/pull/68