### PR TITLE
fix: resolve a resumed Activity at load when a non-Activity context is passed [HB-11488]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ All official releases can be found on this repository's [releases page](https://
 
 ## Mediation 5
 
+### 5.9.2.0.0.1
+- Fix fullscreen ad queue loads failing with a non-`Activity` context by resolving ironSource's currently resumed `Activity` at load.
+
 ### 5.9.2.0.0.0
 - This version of the adapter has been certified with ironSource SDK 9.2.0.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All official releases can be found on this repository's [releases page](https://
 ## Mediation 5
 
 ### 5.9.2.0.0.1
+- This version of the adapter has been certified with ironSource SDK 9.2.0.
 - Fix fullscreen ad queue loads failing with a non-`Activity` context by resolving ironSource's currently resumed `Activity` at load.
 
 ### 5.9.2.0.0.0

--- a/IronSourceAdapter/build.gradle.kts
+++ b/IronSourceAdapter/build.gradle.kts
@@ -43,7 +43,7 @@ android {
         minSdk = 21
         targetSdk = 34
         // If you touch the following line, don't forget to update scripts/get_rc_version.zsh
-        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "5.9.2.0.0.0"
+        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "5.9.2.0.0.1"
 
         buildConfigField("String", "CHARTBOOST_MEDIATION_IRONSOURCE_ADAPTER_VERSION", "\"${android.defaultConfig.versionName}\"")
 

--- a/IronSourceAdapter/src/main/java/com/chartboost/mediation/ironsourceadapter/IronSourceAdapter.kt
+++ b/IronSourceAdapter/src/main/java/com/chartboost/mediation/ironsourceadapter/IronSourceAdapter.kt
@@ -242,7 +242,7 @@ class IronSourceAdapter : PartnerAdapter {
     ): Result<PartnerAd> {
         PartnerLogController.log(LOAD_STARTED)
 
-        // ironSource requires an Activity at load. When the caller supplies a non-Activity
+        // IronSource requires an Activity at load. When the caller supplies a non-Activity
         // context (e.g. fullscreen ad queues, which retain only the application context), fall
         // back to the Activity ironSource itself tracks as currently resumed. ContextProvider
         // never clears its reference, so guard against a finishing/destroyed Activity.

--- a/IronSourceAdapter/src/main/java/com/chartboost/mediation/ironsourceadapter/IronSourceAdapter.kt
+++ b/IronSourceAdapter/src/main/java/com/chartboost/mediation/ironsourceadapter/IronSourceAdapter.kt
@@ -267,7 +267,7 @@ class IronSourceAdapter : PartnerAdapter {
                 }
             }
         } ?: run {
-            PartnerLogController.log(LOAD_FAILED, "No Activity available. ironSource requires a foreground Activity to load ads.")
+            PartnerLogController.log(LOAD_FAILED, "No Activity available. IronSource requires a foreground Activity to load ads.")
             Result.failure(ChartboostMediationAdException(ChartboostMediationError.LoadError.ActivityNotFound))
         }
     }

--- a/IronSourceAdapter/src/main/java/com/chartboost/mediation/ironsourceadapter/IronSourceAdapter.kt
+++ b/IronSourceAdapter/src/main/java/com/chartboost/mediation/ironsourceadapter/IronSourceAdapter.kt
@@ -50,6 +50,7 @@ import com.chartboost.core.consent.ConsentKeys
 import com.chartboost.core.consent.ConsentManagementPlatform
 import com.chartboost.core.consent.ConsentValue
 import com.chartboost.core.consent.ConsentValues
+import com.ironsource.environment.ContextProvider
 import com.ironsource.mediationsdk.IronSource
 import com.ironsource.mediationsdk.demandOnly.ISDemandOnlyInterstitialListener
 import com.ironsource.mediationsdk.demandOnly.ISDemandOnlyRewardedVideoListener
@@ -153,8 +154,6 @@ class IronSourceAdapter : PartnerAdapter {
             .takeIf { it.isNotEmpty() }?.let { appKey ->
                 suspendCancellableCoroutine { continuation ->
                     IronSource.setMediationType("Chartboost")
-                    // IronSource leaks this Activity via ContextProvider, but it only ever leaks one
-                    // Activity at a time, so this is probably okay.
 
                     val initRequest = LevelPlayInitRequest.Builder(appKey)
                         .build()
@@ -243,14 +242,23 @@ class IronSourceAdapter : PartnerAdapter {
     ): Result<PartnerAd> {
         PartnerLogController.log(LOAD_STARTED)
 
-        return (context as? Activity)?.let { activity ->
+        // ironSource requires an Activity at load. When the caller supplies a non-Activity
+        // context (e.g. fullscreen ad queues, which retain only the application context), fall
+        // back to the Activity ironSource itself tracks as currently resumed. ContextProvider
+        // never clears its reference, so guard against a finishing/destroyed Activity.
+        val activity =
+            context as? Activity
+                ?: ContextProvider.getInstance().currentActiveActivity
+                    ?.takeIf { !it.isFinishing && !it.isDestroyed }
+
+        return activity?.let {
             when (request.format) {
                 PartnerAdFormats.INTERSTITIAL -> {
-                    loadInterstitialAd(activity, request, partnerAdListener)
+                    loadInterstitialAd(it, request, partnerAdListener)
                 }
 
                 PartnerAdFormats.REWARDED -> {
-                    loadRewardedAd(activity, request, partnerAdListener)
+                    loadRewardedAd(it, request, partnerAdListener)
                 }
 
                 else -> {
@@ -259,7 +267,7 @@ class IronSourceAdapter : PartnerAdapter {
                 }
             }
         } ?: run {
-            PartnerLogController.log(LOAD_FAILED, "Activity context is required.")
+            PartnerLogController.log(LOAD_FAILED, "No Activity available. ironSource requires a foreground Activity to load ads.")
             Result.failure(ChartboostMediationAdException(ChartboostMediationError.LoadError.ActivityNotFound))
         }
     }


### PR DESCRIPTION
## Summary
Part of [HB-11488]: the Mediation fullscreen ad queue now retains only the application context, so this adapter can no longer rely on the caller passing an Activity at load.

## Changes
- `load()` falls back to ironSource's own currently-resumed Activity (`ContextProvider.getInstance().currentActiveActivity`) when the caller's context isn't an Activity, guarded with `takeIf { !it.isFinishing && !it.isDestroyed }` since ContextProvider never clears its reference.
- Fails cleanly with `ActivityNotFound` when no Activity is resumed (e.g. app backgrounded); the queue's delayed retry handles the rest.
- Version bump `5.9.2.0.0.0` → `5.9.2.0.0.1` + CHANGELOG entry; removed a stale comment in `setUp()`.

Companion PRs: main repo (queue fix) and the Mintegral adapter.

[HB-11488]: https://loopme.atlassian.net/browse/HB-11488